### PR TITLE
Hotfix - Null check for unreproduceable multipart error.

### DIFF
--- a/lib/helpers/Parser.js
+++ b/lib/helpers/Parser.js
@@ -474,7 +474,7 @@ function parseBodyStructure(cur, literals, prefix, partID) {
                                     prefix + (prefix !== '' ? '.' : '')
                                            + (partID++).toString(), 1));
       }
-      part = { type: cur[next++] ? cur[next].toLowerCase() : null };
+      part = { type: (cur[next] && typeof cur[next] === 'string') ? cur[next++].toLowerCase() : null };
       if (partLen > next) {
         if (Array.isArray(cur[next])) {
           part.params = {};

--- a/lib/helpers/Parser.js
+++ b/lib/helpers/Parser.js
@@ -474,7 +474,7 @@ function parseBodyStructure(cur, literals, prefix, partID) {
                                     prefix + (prefix !== '' ? '.' : '')
                                            + (partID++).toString(), 1));
       }
-      part = { type: cur[next++].toLowerCase() };
+      part = { type: cur[next++] ? cur[next].toLowerCase() : null };
       if (partLen > next) {
         if (Array.isArray(cur[next])) {
           part.params = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klenty/imap",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Wrapper over node-imap, providing a simpler api for common use cases",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
* fix(lib/Parser): Added type check for unreproduce-able bug.

Error stack trace
```
TypeError: cur[(next++)].toLowerCase is not a function
at parseBodyStructure (/app/node_modules/@klenty/imap/lib/helpers/Parser.js:477:34)
at parseBodyStructure (/app/node_modules/@klenty/imap/lib/helpers/Parser.js:472:18)
at parseBodyStructure (/app/node_modules/@klenty/imap/lib/helpers/Parser.js:466:13)
at Parser.parseFetch (/app/node_modules/@klenty/imap/lib/helpers/Parser.js:440:13)
```

Upon testing all MIME Content-Type's we were not able to identify for which type this error would throw in production. Added this type check so that the error does not bubble up to the main thread and crash the process.